### PR TITLE
Streamline seed helpers and shared UI styling

### DIFF
--- a/data.js
+++ b/data.js
@@ -23,13 +23,136 @@ const ASSETS = {
     ambient: "assets/fx/ambient.png",
   },
   sfx: {
-    step: "assets/audio/step.wav",
+    step_grass: "assets/audio/step_grass.wav",
+    step_dirt: "assets/audio/step_dirt.wav",
+    step_stone: "assets/audio/step.wav",
     pickup: "assets/audio/pickup.wav",
     ui: "assets/audio/ui.wav",
-    splash: "assets/audio/splash.wav"
+    splash: "assets/audio/splash.wav",
     // plant: "assets/audio/plant.wav" // nur eintragen, wenn Datei wirklich existiert!
   }
 };
+
+const CONTROL_HINTS = [
+  { key: "WASD/←↑→↓", desc: "Bewegen" },
+  { key: "Shift", desc: "Sprint" },
+  { key: "E/Leertaste", desc: "Aktion" },
+  { key: "Q/E oder Mausrad", desc: "Saat wechseln" },
+  { key: "1-3", desc: "Direktwahl Saat" },
+  { key: "4", desc: "Stein setzen" },
+  { key: "Esc", desc: "Pause" },
+];
+
+const SEEDS = [
+  {
+    id: "cabbage",
+    name: "Kohl",
+    sprite: ASSETS.sprites.cabbage,
+    icon: ASSETS.sprites.cabbage,
+    growTime: 30,
+    yield: 1,
+    hotkey: "1",
+    harvest: { inventory: "seeds", id: "cabbage" },
+    shop: {
+      goodId: "cabbage_seed",
+      name: "Kohlsamen",
+      description: "Robuste Knolle, die schnell und verlässlich wächst.",
+      cost: 3,
+      amount: 1,
+    },
+  },
+  {
+    id: "corn",
+    name: "Mais",
+    sprite: ASSETS.sprites.corn,
+    icon: ASSETS.sprites.corn,
+    growTime: 40,
+    yield: 1,
+    hotkey: "2",
+    harvest: { inventory: "seeds", id: "corn" },
+    shop: {
+      goodId: "corn_seed",
+      name: "Maissamen",
+      description: "Braucht etwas länger, liefert dafür eine satte Ernte.",
+      cost: 4,
+      amount: 1,
+    },
+  },
+  {
+    id: "flower",
+    name: "Blume",
+    sprite: ASSETS.sprites.flower,
+    icon: ASSETS.sprites.flower,
+    growTime: 20,
+    yield: 1,
+    hotkey: "3",
+    harvest: { inventory: "flowers" },
+    shop: {
+      goodId: "flower_seed",
+      name: "Blumensamen",
+      description: "Bringt Duft und Farbe auf jedes Beet.",
+      cost: 5,
+      amount: 1,
+    },
+  },
+];
+
+const SEED_MAP = Object.fromEntries(SEEDS.map(seed => [seed.id, seed]));
+const SEED_ORDER = SEEDS.map(seed => seed.id);
+const SEED_HOTKEYS = SEEDS
+  .filter(seed => seed.hotkey)
+  .map(seed => [seed.hotkey, seed.id]);
+
+const SHOP_GOODS = [
+  ...SEEDS.map(seed => ({
+    id: seed.shop?.goodId ?? `${seed.id}_seed`,
+    name: seed.shop?.name ?? `${seed.name}-Samen`,
+    icon: seed.icon,
+    type: "seed",
+    seed: seed.id,
+    amount: seed.shop?.amount ?? 1,
+    cost: seed.shop?.cost ?? 0,
+    description: seed.shop?.description ?? "",
+  })),
+  {
+    id: "veggie_pack",
+    name: "Gemüsekiste",
+    icon: ASSETS.tiles.wood,
+    type: "bundle",
+    contents: { cabbage: 2, corn: 1 },
+    cost: 7,
+    description: "Fred packt dir 2x Kohl und 1x Mais in eine rustikale Kiste.",
+  },
+  {
+    id: "bouquet_kit",
+    name: "Strauß-Kit",
+    icon: ASSETS.sprites.flower,
+    type: "bundle",
+    contents: { flower: 3 },
+    cost: 10,
+    description: "Drei Blumensamen für einen duftenden Lieblingsstrauß.",
+  },
+  {
+    id: "stone_block",
+    name: "Steinblock",
+    icon: ASSETS.tiles.rock,
+    type: "stone",
+    amount: 1,
+    cost: 5,
+    description: "Schwerer Block für Mauern, Wege oder Dekoration.",
+  },
+  {
+    id: "path_bundle",
+    name: "Pflaster-Set",
+    icon: ASSETS.tiles.path,
+    type: "stone",
+    amount: 3,
+    cost: 9,
+    description: "Drei bearbeitete Steine für ein ordentliches Wegenetz.",
+  },
+];
+
+const SHOP_GOOD_MAP = Object.fromEntries(SHOP_GOODS.map(good => [good.id, good]));
 
 // Simple tile map (100x100). Houses are static with no-go colliders.
 // 0=grass,1=dirt,2=path,3=rock,4=water,5=wood,6=wall
@@ -87,10 +210,68 @@ const SOLID = new Set([3, 4, 6]);
 
 // NPC spawn points: "in front of house"
 const NPCS = [
-  { id: "fred", x: (30 + 4) * TILE, y: (35 + 7) * TILE + 8 },
-  { id: "berta", x: (60 + 4) * TILE, y: (35 + 7) * TILE + 8 },
-  { id: "stefan", x: (45 + 4) * TILE, y: (60 + 7) * TILE + 8 },
+  {
+    id: "fred",
+    name: "Fred",
+    title: "Gemüsebauer",
+    accent: "#6edb8f",
+    bio: "Fred kümmert sich um alles, was knackig ist. Seine Saat ist günstig und wächst zuverlässig.",
+    greeting: "Frisches Gemüse gefällig? Ich hab' dir die besten Saaten beiseite gelegt.",
+    shop: [
+      { good: "cabbage_seed", price: 2 },
+      { good: "corn_seed", price: 3 },
+      { good: "veggie_pack", price: 7 },
+    ],
+    x: (30 + 4) * TILE,
+    y: (35 + 7) * TILE + 8,
+  },
+  {
+    id: "berta",
+    name: "Berta",
+    title: "Floristin",
+    accent: "#f28dd3",
+    bio: "Berta liebt Duft und Farbe. Bei ihr findest du alles, was deine Felder hübsch macht.",
+    greeting: "Oh hallo! Ein bisschen Farbe für deinen Hof? Schau dir meine Blüten an.",
+    shop: [
+      { good: "flower_seed", price: 5 },
+      { good: "bouquet_kit", price: 10 },
+      { good: "cabbage_seed", price: 3 },
+    ],
+    x: (60 + 4) * TILE,
+    y: (35 + 7) * TILE + 8,
+  },
+  {
+    id: "stefan",
+    name: "Stefan",
+    title: "Baumeister",
+    accent: "#6ab0ff",
+    bio: "Stefan baut Wege und Mauern. Er tauscht gern robuste Steine gegen ein paar Rubel.",
+    greeting: "Servus! Mit dem richtigen Material wird dein Hof richtig fein.",
+    shop: [
+      { good: "stone_block", price: 5 },
+      { good: "path_bundle", price: 9 },
+      { good: "corn_seed", price: 4 },
+    ],
+    x: (45 + 4) * TILE,
+    y: (60 + 7) * TILE + 8,
+  },
 ];
 
-export { ASSETS, MAP_W, MAP_H, TILE, TILES, map, SOLID, HOUSES, NPCS };
-export { ASSETS, MAP_W, MAP_H, TILE, TILES, map, SOLID, HOUSES, NPCS };
+export {
+  ASSETS,
+  MAP_W,
+  MAP_H,
+  TILE,
+  TILES,
+  map,
+  SOLID,
+  HOUSES,
+  NPCS,
+  CONTROL_HINTS,
+  SEEDS,
+  SEED_MAP,
+  SEED_ORDER,
+  SEED_HOTKEYS,
+  SHOP_GOODS,
+  SHOP_GOOD_MAP,
+};

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1"/>
-  <title>Poopboy v0.9</title>
+  <title>Poopboy v1.0</title>
   <link rel="icon" href="data:,">
   <link rel="preload" href="assets/sprites/player.png" as="image">
   <link rel="preload" href="assets/tiles/grass.png" as="image">
@@ -12,17 +12,29 @@
 <body>
   <div id="ui">
     <div class="topbar">
-      <span id="fps">FPS</span>
-      <span id="stamina">Stamina</span>
-      <span id="money">₽ 0</span>
-      <span id="clock">06:00</span>
-      <span id="hint">WASD/←↑→↓: Bewegen • E: Interagieren • Shift: Sprint • 1-3: Pflanzen • Q/E: Auswahl • Esc: Pause</span>
+      <div class="topbar__row">
+        <span id="fps" class="top-pill">FPS</span>
+        <span id="stamina" class="top-pill top-pill--meter">Ausdauer</span>
+        <span id="money" class="top-pill">₽ 0</span>
+        <span id="clock" class="top-pill">06:00</span>
+      </div>
+      <div id="hint" class="topbar__hint"></div>
+    </div>
+    <div class="bottom-ui">
+      <div id="seed-wheel" class="seed-wheel"></div>
+      <div id="context-hint" class="context-hint hidden"></div>
     </div>
     <div id="shop" class="panel hidden">
       <div class="panel-inner">
-        <h3>Shop</h3>
-        <div id="shop-items"></div>
-        <button id="shop-close">Schließen</button>
+        <div class="shop-header">
+          <img id="shop-portrait" class="shop-portrait" src="data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=" alt="" width="72" height="72"/>
+          <div class="shop-header__text">
+            <h3 id="shop-title">Shop</h3>
+            <p id="shop-subtitle"></p>
+          </div>
+          <button id="shop-close" class="shop-close" aria-label="Schließen">×</button>
+        </div>
+        <div id="shop-items" class="shop-items"></div>
       </div>
     </div>
   </div>

--- a/main.js
+++ b/main.js
@@ -1,7 +1,25 @@
 // Poopboy v1.0 — Komplettüberarbeitung: Modular, performant, neue Features, bessere Steuerung, QoL, Bugfixes
 
-import { ASSETS, MAP_W, MAP_H, TILE, TILES, map, SOLID, HOUSES, NPCS } from "./data.js";
+import {
+  ASSETS,
+  MAP_W,
+  MAP_H,
+  TILE,
+  TILES,
+  map,
+  SOLID,
+  HOUSES,
+  NPCS,
+  CONTROL_HINTS,
+  SEEDS,
+  SEED_MAP,
+  SEED_ORDER,
+  SEED_HOTKEYS,
+  SHOP_GOOD_MAP,
+} from "./data.js";
 import { SFX } from "./sfx.js";
+
+const hasOwn = Object.prototype.hasOwnProperty;
 
 // --- Canvas & UI ---
 const canvas = document.getElementById("game");
@@ -16,12 +34,70 @@ const ui = {
   shop: document.getElementById("shop"),
   shopItems: document.getElementById("shop-items"),
   shopClose: document.getElementById("shop-close"),
+  shopTitle: document.getElementById("shop-title"),
+  shopSubtitle: document.getElementById("shop-subtitle"),
+  shopPortrait: document.getElementById("shop-portrait"),
   hint: document.getElementById("hint"),
+  seedWheel: document.getElementById("seed-wheel"),
+  contextHint: document.getElementById("context-hint"),
 };
-ui.shopClose.onclick = () => ui.shop.classList.add("hidden");
 
 // --- Audio ---
 const sfx = new SFX(ASSETS.sfx);
+const DEBUG_OVERLAY = false;
+const DIR_OFFSETS = [
+  [0, 1],
+  [-1, 0],
+  [1, 0],
+  [0, -1],
+];
+
+const MOVEMENT_CONTROLS = [
+  { dir: 3, keys: ["w", "arrowup"], vec: DIR_OFFSETS[3] },
+  { dir: 0, keys: ["s", "arrowdown"], vec: DIR_OFFSETS[0] },
+  { dir: 1, keys: ["a", "arrowleft"], vec: DIR_OFFSETS[1] },
+  { dir: 2, keys: ["d", "arrowright"], vec: DIR_OFFSETS[2] },
+];
+
+function isShopOpen() {
+  return !!(ui.shop && !ui.shop.classList.contains("hidden"));
+}
+
+function closeShop({ silent = false } = {}) {
+  if (!isShopOpen()) return false;
+  ui.shop.classList.add("hidden");
+  if (!silent) {
+    sfx.play("ui", { volume: 0.7, rateRange: [0.96, 1.05] });
+  }
+  detectContext();
+  refreshContextHint();
+  return true;
+}
+
+if (ui.shopClose) {
+  ui.shopClose.onclick = () => closeShop();
+}
+
+const HINT_CONTROLS_HTML = CONTROL_HINTS
+  .map(({ key, desc }) => `<span class="hint-item"><span class="hint-key">${key}</span><span class="hint-desc">${desc}</span></span>`)
+  .join('<span class="hint-sep">•</span>');
+
+const MINIMAP_TILE_COLORS = {
+  0: "#2c7a55",
+  1: "#c9864c",
+  2: "#d2b994",
+  3: "#6c7b91",
+  4: "#3970c2",
+  5: "#8e5a37",
+  6: "#1f262e",
+};
+
+function tileAtWorld(x, y) {
+  const tx = Math.floor(x / TILE);
+  const ty = Math.floor(y / TILE);
+  if (tx < 0 || ty < 0 || tx >= MAP_W || ty >= MAP_H) return 0;
+  return map[ty * MAP_W + tx];
+}
 
 // --- Loader ---
 const IMGS = new Map();
@@ -45,17 +121,28 @@ const once = new Set();
 let paused = false;
 function kd(e) {
   if (e.repeat) return;
+  if (e.key === " " || e.key === "Spacebar" || e.key === "Space") e.preventDefault();
   keys.set(e.key.toLowerCase(), true);
   if (e.key === "Escape") paused = !paused;
 }
 function ku(e) { keys.delete(e.key.toLowerCase()); once.delete(e.key.toLowerCase()); }
 addEventListener("keydown", kd);
 addEventListener("keyup", ku);
+addEventListener("wheel", onWheel, { passive: false });
 function pressed(k) { return keys.has(k); }
 function pressedOnce(k) {
   const k2 = k.toLowerCase();
   if (keys.has(k2) && !once.has(k2)) { once.add(k2); return true; }
   return false;
+}
+
+function onWheel(e) {
+  if (!ui.seedWheel) return;
+  if (isShopOpen()) return;
+  const dir = e.deltaY > 0 ? 1 : -1;
+  if (!dir) return;
+  cycleSeed(dir);
+  e.preventDefault();
 }
 
 // --- Camera ---
@@ -76,33 +163,128 @@ function makeActor(spriteId, x, y) {
     sprite: ASSETS.sprites[spriteId],
     w: 32, h: 38,
     talk: "",
+    displayName: null,
+    accent: "#ffffff",
+    role: "",
+    portrait: ASSETS.sprites[spriteId],
     ai: null,
     state: "",
     wt: 0,
   };
 }
 const player = makeActor("player", 26 * TILE, 54 * TILE);
+player.spd = 2.75;
 player.stamina = 100; player.maxStamina = 100; player.sprint = false; player.money = 0;
-player.inv = { seeds: { cabbage: 0, corn: 0, flower: 0 }, stones: 0, flowers: 0 };
-player.selectedSeed = "cabbage";
+const initialSeedInventory = Object.fromEntries(SEED_ORDER.map(id => [id, 0]));
+player.inv = { seeds: initialSeedInventory, stones: 0, flowers: 0 };
+player.selectedSeed = SEED_ORDER[0] ?? (SEEDS[0]?.id ?? "");
+
+function ensureSeedSlot(id) {
+  if (!hasOwn.call(player.inv.seeds, id)) {
+    player.inv.seeds[id] = 0;
+  }
+}
+
+function getSeedCount(id) {
+  ensureSeedSlot(id);
+  return player.inv.seeds[id];
+}
+
+function setSeedCount(id, value) {
+  ensureSeedSlot(id);
+  const clamped = Math.max(0, value);
+  player.inv.seeds[id] = clamped;
+  return clamped;
+}
+
+function addSeeds(id, amount = 1) {
+  return setSeedCount(id, getSeedCount(id) + amount);
+}
+
+function consumeSeeds(id, amount = 1) {
+  const current = getSeedCount(id);
+  if (current < amount) return false;
+  setSeedCount(id, current - amount);
+  return true;
+}
+
+function hasSeeds(id, amount = 1) {
+  return getSeedCount(id) >= amount;
+}
 
 // --- NPCs ---
 const actors = [player];
 for (const n of NPCS) {
   const a = makeActor(n.id, n.x, n.y);
-  a.spd = 1.3;
-  a.talk = `Hallo, ich bin ${n.id.charAt(0).toUpperCase() + n.id.slice(1)}.`;
+  a.spd = 1.35;
+  a.talk = n.greeting;
+  a.displayName = `${n.name}`;
+  a.role = n.title;
+  a.accent = n.accent;
+  a.meta = n;
   a.ai = "wander";
   actors.push(a);
 }
 
 // --- Pflanzen (neues System) ---
 const plants = [];
-const PLANT_TYPES = {
-  cabbage: { growTime: 30, sprite: "assets/sprites/cabbage.png", yield: 1, name: "Kohl" },
-  corn: { growTime: 40, sprite: "assets/sprites/corn.png", yield: 1, name: "Mais" },
-  flower: { growTime: 20, sprite: "assets/sprites/flower.png", yield: 1, name: "Blume" },
-};
+const seedCards = [];
+
+function buildSeedWheel() {
+  if (!ui.seedWheel) return;
+  ui.seedWheel.innerHTML = "";
+  seedCards.length = 0;
+  SEEDS.forEach((seed, idx) => {
+    const { id } = seed;
+    ensureSeedSlot(id);
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "seed-card";
+    button.dataset.seed = id;
+
+    const iconWrap = document.createElement("span");
+    iconWrap.className = "seed-card__icon";
+    const icon = document.createElement("img");
+    icon.src = seed.icon || seed.sprite;
+    icon.alt = seed.name;
+    icon.width = 28;
+    icon.height = 28;
+    iconWrap.appendChild(icon);
+
+    const label = document.createElement("span");
+    label.className = "seed-card__label";
+    label.textContent = seed.name;
+
+    const count = document.createElement("span");
+    count.className = "seed-card__count";
+    count.textContent = "x0";
+
+    const hotkey = document.createElement("span");
+    hotkey.className = "seed-card__hotkey";
+    hotkey.textContent = seed.hotkey || idx + 1;
+
+    button.append(iconWrap, label, count, hotkey);
+    button.addEventListener("click", () => {
+      player.selectedSeed = id;
+      onSeedChanged(true);
+    });
+
+    ui.seedWheel.appendChild(button);
+    seedCards.push({ id, button, countEl: count, labelEl: label });
+  });
+}
+
+function updateSeedWheel() {
+  for (const entry of seedCards) {
+    const amount = getSeedCount(entry.id);
+    entry.countEl.textContent = `x${amount}`;
+    entry.button.classList.toggle("active", player.selectedSeed === entry.id);
+    entry.button.classList.toggle("seed-card--empty", amount <= 0);
+  }
+}
+
+buildSeedWheel();
+updateSeedWheel();
 function plantSeed(seedId, tx, ty) {
   plants.push({ id: seedId, x: tx, y: ty, t: 0, grown: false });
 }
@@ -110,13 +292,16 @@ function updatePlants(dt) {
   for (const p of plants) {
     if (!p.grown) {
       p.t += dt;
-      if (p.t >= PLANT_TYPES[p.id].growTime) p.grown = true;
+      const info = SEED_MAP[p.id];
+      if (info && p.t >= info.growTime) p.grown = true;
     }
   }
 }
 function drawPlants() {
   for (const p of plants) {
-    const spr = img(PLANT_TYPES[p.id].sprite);
+    const info = SEED_MAP[p.id];
+    if (!info) continue;
+    const spr = img(info.sprite);
     if (!spr) continue;
     const px = p.x * TILE - cam.x, py = p.y * TILE - cam.y;
     ctx.globalAlpha = p.grown ? 1 : 0.6;
@@ -124,73 +309,397 @@ function drawPlants() {
     ctx.globalAlpha = 1;
   }
 }
+
+function drawInteractionHighlight() {
+  if (!contextTarget || contextTarget.type === "shop-open") return;
+
+  if (contextTarget.tile) {
+    const { x, y } = contextTarget.tile;
+    if (x >= 0 && y >= 0 && x < MAP_W && y < MAP_H) {
+      const px = x * TILE - cam.x;
+      const py = y * TILE - cam.y;
+      let fill = "rgba(114,239,221,0.25)";
+      let stroke = "rgba(114,239,221,0.9)";
+      if (contextTarget.type === "harvest") {
+        fill = "rgba(255,214,99,0.3)";
+        stroke = "rgba(255,214,99,0.95)";
+      } else if (contextTarget.type === "no-seed") {
+        fill = "rgba(255,118,118,0.22)";
+        stroke = "rgba(255,118,118,0.9)";
+      }
+      ctx.save();
+      ctx.translate(px, py);
+      ctx.fillStyle = fill;
+      ctx.globalAlpha = 0.65;
+      ctx.fillRect(3, 3, TILE - 6, TILE - 6);
+      ctx.globalAlpha = 1;
+      ctx.strokeStyle = stroke;
+      ctx.lineWidth = 2;
+      ctx.strokeRect(3, 3, TILE - 6, TILE - 6);
+      ctx.restore();
+    }
+  }
+
+  if (contextTarget.type === "shop" && contextTarget.npc) {
+    const npc = contextTarget.npc;
+    ctx.save();
+    ctx.translate(npc.x - cam.x, npc.y - cam.y);
+    ctx.fillStyle = npc.accent || "#56cfe1";
+    ctx.globalAlpha = 0.28;
+    ctx.beginPath();
+    ctx.ellipse(0, 6, 28, 14, 0, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.globalAlpha = 1;
+    ctx.strokeStyle = npc.accent || "#56cfe1";
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.ellipse(0, 6, 30, 16, 0, 0, Math.PI * 2);
+    ctx.stroke();
+    ctx.restore();
+  }
+}
 function harvestPlantAt(tx, ty) {
   for (let i = 0; i < plants.length; ++i) {
     const p = plants[i];
     if (p.x === tx && p.y === ty && p.grown) {
-      player.inv[p.id === "flower" ? "flowers" : "seeds"][p.id] += PLANT_TYPES[p.id].yield;
+      const info = SEED_MAP[p.id];
+      const amount = info?.yield ?? 1;
+      const harvest = info?.harvest || { inventory: "seeds", id: p.id };
+      if (harvest.inventory === "seeds") {
+        const targetId = harvest.id ?? p.id;
+        addSeeds(targetId, amount);
+      } else {
+        const key = harvest.inventory;
+        player.inv[key] = (player.inv[key] ?? 0) + amount;
+      }
       plants.splice(i, 1);
-      sfx.play("pickup", 0.9);
+      sfx.play("pickup", { volume: 0.85, rateRange: [0.95, 1.05], detuneRange: 35 });
       return true;
     }
   }
   return false;
 }
 
+const INTERACTION_DISTANCE = 60;
+let contextTarget = null;
+let contextHintKey = null;
+
+function tileInBounds(tile) {
+  return tile.x >= 0 && tile.y >= 0 && tile.x < MAP_W && tile.y < MAP_H;
+}
+
+function getPlayerTile() {
+  return {
+    x: Math.floor(player.x / TILE),
+    y: Math.floor(player.y / TILE),
+  };
+}
+
+function getFacingTile(base = getPlayerTile()) {
+  const [ox, oy] = DIR_OFFSETS[player.dir] ?? DIR_OFFSETS[0];
+  return { x: base.x + ox, y: base.y + oy };
+}
+
+function findNearbyNPC() {
+  let best = null;
+  let bestDist = Infinity;
+  for (const a of actors) {
+    if (a === player) continue;
+    const d = Math.hypot(a.x - player.x, a.y - player.y);
+    if (d < INTERACTION_DISTANCE && d < bestDist) {
+      best = a;
+      bestDist = d;
+    }
+  }
+  return best;
+}
+
+function detectContext() {
+  if (isShopOpen()) {
+    contextTarget = { type: "shop-open" };
+    return;
+  }
+
+  const origin = getPlayerTile();
+  const facing = getFacingTile(origin);
+  const tiles = [facing, origin];
+
+  for (const tile of tiles) {
+    if (!tileInBounds(tile)) continue;
+    const plant = plants.find(p => p.x === tile.x && p.y === tile.y);
+    if (plant && plant.grown) {
+      contextTarget = { type: "harvest", tile, plant };
+      return;
+    }
+  }
+
+  for (const tile of tiles) {
+    if (!tileInBounds(tile)) continue;
+    if (plants.some(p => p.x === tile.x && p.y === tile.y)) continue;
+    if (!isPlantableTile(map[tile.y * MAP_W + tile.x])) continue;
+    if (hasSeeds(player.selectedSeed)) {
+      contextTarget = { type: "plant", tile, seed: player.selectedSeed };
+    } else {
+      contextTarget = { type: "no-seed", tile, seed: player.selectedSeed };
+    }
+    return;
+  }
+
+  const npc = findNearbyNPC();
+  if (npc) {
+    contextTarget = { type: "shop", npc };
+    return;
+  }
+
+  contextTarget = null;
+}
+
+function refreshContextHint() {
+  if (!ui.contextHint) return;
+  let key = "none";
+  let text = "";
+  let icon = "";
+
+  if (!contextTarget || contextTarget.type === "shop-open") {
+    if (contextHintKey !== key) {
+      ui.contextHint.classList.add("hidden");
+      ui.contextHint.innerHTML = "";
+      contextHintKey = key;
+    }
+    return;
+  }
+
+  switch (contextTarget.type) {
+    case "plant": {
+      const info = SEED_MAP[contextTarget.seed] || SEED_MAP[player.selectedSeed];
+      key = `plant:${contextTarget.seed}`;
+      text = `E • ${info ? info.name : "Saat"} pflanzen`;
+      icon = info?.icon || info?.sprite || "";
+      break;
+    }
+    case "no-seed": {
+      const info = SEED_MAP[contextTarget.seed] || SEED_MAP[player.selectedSeed];
+      key = `no-seed:${contextTarget.seed}`;
+      text = info ? `Keine ${info.name}-Samen übrig` : "Keine Samen übrig";
+      icon = info?.icon || info?.sprite || "";
+      break;
+    }
+    case "harvest": {
+      const info = SEED_MAP[contextTarget.plant.id];
+      key = `harvest:${contextTarget.plant.id}`;
+      text = `E • ${info ? info.name : "Ernte"} einsammeln`;
+      icon = info?.icon || info?.sprite || "";
+      break;
+    }
+    case "shop": {
+      const npc = contextTarget.npc;
+      key = `shop:${npc.displayName}`;
+      text = `E • mit ${npc.displayName} handeln`;
+      icon = npc.meta ? ASSETS.sprites[npc.meta.id] : npc.sprite;
+      break;
+    }
+    default:
+      key = "none";
+      break;
+  }
+
+  if (contextHintKey === key) return;
+  contextHintKey = key;
+
+  ui.contextHint.innerHTML = "";
+  if (icon) {
+    const imgEl = document.createElement("img");
+    imgEl.src = icon;
+    imgEl.alt = "";
+    imgEl.width = 28;
+    imgEl.height = 28;
+    imgEl.className = "context-hint__icon";
+    ui.contextHint.appendChild(imgEl);
+  }
+  const label = document.createElement("span");
+  label.className = "context-hint__label";
+  label.textContent = text;
+  ui.contextHint.appendChild(label);
+  ui.contextHint.classList.toggle("context-hint--warning", contextTarget.type === "no-seed");
+  ui.contextHint.classList.remove("hidden");
+}
+
+function onSeedChanged(playSound = false) {
+  onInventoryChanged();
+  if (playSound) sfx.play("ui", { volume: 0.55, rateRange: [0.9, 1.08], detuneRange: 12 });
+}
+
+function onInventoryChanged() {
+  updateSeedWheel();
+  renderTopbar();
+  detectContext();
+  refreshContextHint();
+}
+
+function performPrimaryAction() {
+  if (closeShop()) {
+    return true;
+  }
+  if (!contextTarget) return false;
+  switch (contextTarget.type) {
+    case "plant":
+      if (tryPlant(player.selectedSeed, contextTarget.tile.x, contextTarget.tile.y)) {
+        onInventoryChanged();
+        return true;
+      }
+      break;
+    case "no-seed":
+      sfx.play("ui", { volume: 0.4, rateRange: [0.82, 0.9], detuneRange: 20 });
+      return false;
+    case "harvest":
+      if (harvestPlantAt(contextTarget.tile.x, contextTarget.tile.y)) {
+        onInventoryChanged();
+        return true;
+      }
+      break;
+    case "shop":
+      openShop(contextTarget.npc);
+      contextTarget = { type: "shop-open" };
+      refreshContextHint();
+      return true;
+    default:
+      break;
+  }
+  detectContext();
+  refreshContextHint();
+  return false;
+}
+
+onInventoryChanged();
+
 // --- Physics ---
+function collideRect(ax, ay, aw, ah) {
+  const minx = Math.floor(ax / TILE);
+  const maxx = Math.floor((ax + aw - 1) / TILE);
+  const miny = Math.floor(ay / TILE);
+  const maxy = Math.floor((ay + ah - 1) / TILE);
+  for (let ty = miny; ty <= maxy; ty++) {
+    for (let tx = minx; tx <= maxx; tx++) {
+      if (tx < 0 || ty < 0 || tx >= MAP_W || ty >= MAP_H) {
+        return { x: tx * TILE, y: ty * TILE, w: TILE, h: TILE };
+      }
+      const tile = map[ty * MAP_W + tx];
+      if (SOLID.has(tile)) {
+        return { x: tx * TILE, y: ty * TILE, w: TILE, h: TILE };
+      }
+    }
+  }
+  return null;
+}
+
 // Robuste Kollision: Separat X und Y, damit man an Wänden entlanggleiten kann
 function resolve(a) {
-  if (a === player) {
-    // Teste X separat
-    let origX = a.x;
-    let r = collideRect(a.x - 16, a.y - 32, a.w, a.h);
-    if (r) {
-      // Versuche, X zu korrigieren
-      if (origX < r.x) a.x = r.x - 1;
-      else if (origX > r.x + r.w) a.x = r.x + r.w + 1;
-    }
-    // Teste Y separat (X bleibt korrigiert)
-    let origY = a.y;
-    r = collideRect(a.x - 16, a.y - 32, a.w, a.h);
-    if (r) {
-      if (origY < r.y) a.y = r.y - 1;
-      else if (origY > r.y + r.h) a.y = r.y + r.h + 1;
-    }
-  } else {
-    // NPCs werden leicht abgestoßen
+  const maxIter = 4;
+  for (let i = 0; i < maxIter; i++) {
     const r = collideRect(a.x - 16, a.y - 32, a.w, a.h);
-    if (r) {
+    if (!r) break;
+    if (a === player) {
+      const ax = a.x - 16;
+      const ay = a.y - 32;
+      const overlapX = Math.min(ax + a.w, r.x + r.w) - Math.max(ax, r.x);
+      const overlapY = Math.min(ay + a.h, r.y + r.h) - Math.max(ay, r.y);
+      if (overlapX <= 0 || overlapY <= 0) break;
+      if (overlapX < overlapY) {
+        const push = overlapX + 0.1;
+        if (ax < r.x) a.x -= push;
+        else a.x += push;
+      } else {
+        const push = overlapY + 0.1;
+        if (ay < r.y) a.y -= push;
+        else a.y += push;
+      }
+    } else {
       a.x += (Math.random() - 0.5) * 2;
       a.y += (Math.random() - 0.5) * 2;
+      break;
     }
   }
 }
 
 // --- Shop ---
-const SHOP_ITEMS = [
-  { id: "cabbage", name: "Kohlsamen", price: 3 },
-  { id: "corn", name: "Maissamen", price: 2 },
-  { id: "flower", name: "Blumensamen", price: 4 },
-  { id: "stone", name: "Schwerer Stein", price: 5 },
-];
-function openShop() {
-  ui.shopItems.innerHTML = "";
-  for (const it of SHOP_ITEMS) {
-    const b = document.createElement("button");
-    b.textContent = `${it.name} – ₽${it.price}`;
-    b.onclick = () => {
-      if (player.money >= it.price) {
-        player.money -= it.price;
-        if (it.id === "stone") player.inv.stones += 1;
-        else if (it.id === "flower") player.inv.seeds.flower += 1;
-        else player.inv.seeds[it.id] += 1;
-        sfx.play("ui", 0.7);
-        renderTopbar();
-      }
-    };
-    ui.shopItems.appendChild(b);
+function applyPurchase(good) {
+  if (!good) return;
+  if (good.type === "seed") {
+    const seedId = good.seed;
+    addSeeds(seedId, good.amount ?? 1);
+  } else if (good.type === "bundle") {
+    const contents = good.contents || {};
+    for (const [seedId, amount] of Object.entries(contents)) {
+      addSeeds(seedId, amount ?? 0);
+    }
+  } else if (good.type === "stone") {
+    player.inv.stones += good.amount ?? 1;
+  } else if (good.type === "flowers") {
+    player.inv.flowers = (player.inv.flowers ?? 0) + (good.amount ?? 1);
   }
+  sfx.play("pickup", { volume: 0.68, rateRange: [0.96, 1.06], detuneRange: 22 });
+}
+
+function openShop(npc) {
+  if (!npc || !npc.meta) return;
+  const meta = npc.meta;
+  ui.shopItems.innerHTML = "";
+  ui.shopItems.scrollTop = 0;
+  if (ui.shopTitle) ui.shopTitle.textContent = `${meta.name} · ${meta.title}`;
+  if (ui.shopSubtitle) ui.shopSubtitle.textContent = meta.bio || "";
+  if (ui.shopPortrait) {
+    ui.shopPortrait.src = ASSETS.sprites[meta.id];
+    ui.shopPortrait.alt = meta.name;
+  }
+  if (ui.shop) ui.shop.style.setProperty("--shop-accent", meta.accent || "#56cfe1");
+
+  for (const entry of meta.shop) {
+    const good = SHOP_GOOD_MAP[entry.good];
+    if (!good) continue;
+    const priceValue = entry.price ?? good.cost ?? 0;
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "shop-item";
+
+    const iconWrap = document.createElement("span");
+    iconWrap.className = "shop-item__icon";
+    const icon = document.createElement("img");
+    icon.src = good.icon;
+    icon.alt = good.name;
+    icon.width = 40;
+    icon.height = 40;
+    iconWrap.appendChild(icon);
+
+    const info = document.createElement("span");
+    info.className = "shop-item__info";
+    const title = document.createElement("strong");
+    title.className = "shop-item__title";
+    title.textContent = good.name;
+    const desc = document.createElement("span");
+    desc.className = "shop-item__desc";
+    desc.textContent = good.description;
+    info.append(title, desc);
+
+    const price = document.createElement("span");
+    price.className = "shop-item__price";
+    price.textContent = `₽ ${priceValue}`;
+
+    button.append(iconWrap, info, price);
+    button.addEventListener("click", () => {
+      if (player.money < priceValue) {
+        sfx.play("ui", { volume: 0.45, rateRange: [0.72, 0.85], detuneRange: 30 });
+        return;
+      }
+      player.money -= priceValue;
+      applyPurchase(good);
+      onInventoryChanged();
+    });
+
+    ui.shopItems.appendChild(button);
+  }
+
   ui.shop.classList.remove("hidden");
+  sfx.play("ui", { volume: 0.7, rateRange: [0.96, 1.05] });
 }
 
 // --- Zeit & UI ---
@@ -203,24 +712,62 @@ function timeTick(dt) {
   ui.clock.textContent = `${hh}:${mm}`;
 }
 function renderTopbar() {
-  ui.fps.textContent = `${fps.toFixed(0)} FPS`;
-  ui.stam.textContent = `Ausdauer: ${Math.round(player.stamina)}`;
-  ui.money.textContent = `₽ ${player.money}`;
-  ui.hint.textContent = `WASD/←↑→↓: Bewegen • E: Interagieren • Shift: Sprint • 1-3: Pflanzen • Q/E: Auswahl`;
+  ui.fps.textContent = `${Math.round(fps)} FPS`;
+  ui.stam.textContent = `Ausdauer ${Math.round(player.stamina)}/${player.maxStamina}`;
+  ui.stam.style.setProperty("--fill", Math.max(0, Math.min(1, player.stamina / player.maxStamina)).toFixed(3));
+  ui.money.textContent = `₽ ${player.money.toLocaleString("de-DE")}`;
+  const selected = SEED_MAP[player.selectedSeed];
+  const flowers = player.inv.flowers ?? 0;
+  const inventoryParts = [
+    `<span class="hint-item emphasised">Aktive Saat: <span class="hint-badge">${selected ? selected.name : "?"}</span></span>`,
+    `<span class="hint-item emphasised">Blumen: <span class="hint-count">${flowers}</span></span>`,
+    `<span class="hint-item emphasised">Steine: <span class="hint-count">${player.inv.stones}</span></span>`,
+  ];
+  ui.hint.innerHTML = `${HINT_CONTROLS_HTML}<span class="hint-sep hint-gap">|</span>${inventoryParts.join('<span class="hint-sep">•</span>')}`;
 }
 
 // --- Movement + Stamina ---
+const STEP_INTERVAL_WALK = 180;
+const STEP_INTERVAL_SPRINT = 130;
 let lastStep = 0;
 let lastMoveDir = { x: 0, y: 1 }; // Start: unten
 
+function footstepKey() {
+  const tile = tileAtWorld(player.x, player.y + 12);
+  if (tile === 1) return "step_dirt";
+  if (tile === 2 || tile === 3 || tile === 5) return "step_stone";
+  return "step_grass";
+}
+
+function triggerFootstep(sprinting) {
+  const key = footstepKey();
+  const base = sprinting ? 0.74 : 0.6;
+  const volume = key === "step_stone" ? base + 0.06 : key === "step_dirt" ? base + 0.03 : base;
+  sfx.play(key, {
+    volume,
+    rateRange: [0.92, 1.08],
+    detuneRange: 45,
+    offsetRange: 0.01,
+  });
+}
+
 function controlPlayer(dt) {
   let dx = 0, dy = 0;
-  if (pressed("w") || pressed("arrowup")) { dy -= 1; player.dir = 3; }
-  if (pressed("s") || pressed("arrowdown")) { dy += 1; player.dir = 0; }
-  if (pressed("a") || pressed("arrowleft")) { dx -= 1; player.dir = 1; }
-  if (pressed("d") || pressed("arrowright")) { dx += 1; player.dir = 2; }
+  let facingDir = null;
+  for (const control of MOVEMENT_CONTROLS) {
+    if (control.keys.some(key => pressed(key))) {
+      const [vx, vy] = control.vec;
+      dx += vx;
+      dy += vy;
+      facingDir = control.dir;
+    }
+  }
+  if (facingDir !== null) {
+    player.dir = facingDir;
+  }
   const sprinting = pressed("shift") && player.stamina > 0;
   const spd = player.spd * (sprinting ? 1.85 : 1);
+  const now = performance.now();
   if (dx || dy) {
     lastMoveDir.x = dx;
     lastMoveDir.y = dy;
@@ -228,15 +775,12 @@ function controlPlayer(dt) {
     dx *= invLen; dy *= invLen;
     player.x += dx * spd * dt * 60;
     player.y += dy * spd * dt * 60;
-    // Schritt-Sound nur alle 0.22s und nur wenn wirklich bewegt und Sound geladen
-    if (performance.now() - lastStep > 220 && sfx.enabled) {
-      const stepAudio = sfx.buf.get("step");
-      if (stepAudio && stepAudio.src && stepAudio.src.length > 0) {
-        sfx.play("step", 0.7);
-      }
-      lastStep = performance.now();
+    const interval = sprinting ? STEP_INTERVAL_SPRINT : STEP_INTERVAL_WALK;
+    if (now - lastStep > interval) {
+      triggerFootstep(sprinting);
+      lastStep = now;
     }
-    player.anim = (player.anim + dt * 8) % 3;
+    player.anim = (player.anim + dt * (sprinting ? 14 : 10)) % 3;
     if (sprinting) { player.stamina = Math.max(0, player.stamina - dt * 18); player.sprint = true; }
     else player.sprint = false;
   } else {
@@ -249,18 +793,30 @@ function controlPlayer(dt) {
   resolve(player);
   focus(player.x, player.y);
 
-  // Interact
-  if (pressedOnce("e")) {
-    // NPC
-    for (const a of actors) {
-      if (a === player) continue;
-      if (Math.hypot(a.x - player.x, a.y - player.y) < 40) {
-        openShop(); sfx.play("ui", 0.8); break;
-      }
+  for (const [key, id] of SEED_HOTKEYS) {
+    if (pressedOnce(key)) {
+      player.selectedSeed = id;
+      onSeedChanged(true);
     }
-    // Pflanze ernten
-    const tx = Math.floor(player.x / TILE), ty = Math.floor(player.y / TILE);
-    if (harvestPlantAt(tx, ty)) return;
+  }
+
+  if (pressedOnce("4")) {
+    tryPlaceStone();
+  }
+
+  if (pressedOnce("q")) {
+    cycleSeed(-1);
+  }
+
+  if (pressedOnce("e")) {
+    const acted = performPrimaryAction();
+    if (!acted) {
+      cycleSeed(1);
+    }
+  }
+
+  if (pressedOnce(" ") || pressedOnce("space")) {
+    performPrimaryAction();
   }
 }
 
@@ -290,31 +846,36 @@ function updateNPC(a, dt) {
 
 // --- Planting & Stones ---
 function tryPlaceStone() {
-  if (player.inv.stones <= 0) return;
+  if (player.inv.stones <= 0) return false;
   const tx = Math.floor(player.x / TILE);
   const ty = Math.floor(player.y / TILE);
-  const offsets = [[0, 1], [-1, 0], [1, 0], [0, -1]];
-  const [ox, oy] = offsets[player.dir];
+  const [ox, oy] = DIR_OFFSETS[player.dir] ?? DIR_OFFSETS[0];
   const px = tx + ox, py = ty + oy;
-  if (px < 0 || py < 0 || px >= MAP_W || py >= MAP_H) return;
-  if (SOLID.has(map[py * MAP_W + px])) return;
+  if (px < 0 || py < 0 || px >= MAP_W || py >= MAP_H) return false;
+  if (SOLID.has(map[py * MAP_W + px])) return false;
   const wouldOverlap = Math.abs((px + 0.5) * TILE - player.x) < 20 && Math.abs((py + 0.5) * TILE - (player.y - 20)) < 28;
-  if (wouldOverlap) return;
+  if (wouldOverlap) return false;
   map[py * MAP_W + px] = 3;
   player.inv.stones -= 1;
-  sfx.play("pickup", 0.7);
+  sfx.play("pickup", { volume: 0.72, rateRange: [0.9, 1.04], detuneRange: 25 });
+  onInventoryChanged();
+  return true;
 }
 
-function tryPlant(seedId) {
-  if (player.inv.seeds[seedId] <= 0) return;
-  const tx = Math.floor(player.x / TILE), ty = Math.floor(player.y / TILE);
-  if (map[ty * MAP_W + tx] === 0 || map[ty * MAP_W + tx] === 1) {
-    // Check if already plant
-    if (plants.some(p => p.x === tx && p.y === ty)) return;
-    plantSeed(seedId, tx, ty);
-    player.inv.seeds[seedId]--;
-    sfx.play("pickup", 0.8);
-  }
+function isPlantableTile(tile) {
+  return tile === 0 || tile === 1 || tile === 5;
+}
+
+function tryPlant(seedId, tx = Math.floor(player.x / TILE), ty = Math.floor(player.y / TILE)) {
+  if (!hasSeeds(seedId)) return false;
+  if (tx < 0 || ty < 0 || tx >= MAP_W || ty >= MAP_H) return false;
+  const tile = map[ty * MAP_W + tx];
+  if (!isPlantableTile(tile)) return false;
+  if (plants.some(p => p.x === tx && p.y === ty)) return false;
+  if (!consumeSeeds(seedId)) return false;
+  plantSeed(seedId, tx, ty);
+  sfx.play("pickup", { volume: 0.75, rateRange: [0.92, 1.05], detuneRange: 30 });
+  return true;
 }
 
 // --- Rendering ---
@@ -347,7 +908,37 @@ function drawActor(a) {
   const spr = img(a.sprite);
   const frame = Math.floor(a.anim);
   const sx = frame * 48, sy = a.dir * 48;
-  ctx.drawImage(spr, sx, sy, 48, 48, Math.floor(a.x - 24 - cam.x), Math.floor(a.y - 40 - cam.y), 48, 48);
+  const dx = Math.floor(a.x - 24 - cam.x);
+  const dy = Math.floor(a.y - 40 - cam.y);
+  if (a !== player) {
+    ctx.save();
+    ctx.translate(Math.floor(a.x - cam.x), Math.floor(a.y - cam.y));
+    ctx.fillStyle = a.accent || "#56cfe1";
+    ctx.globalAlpha = 0.24;
+    ctx.beginPath();
+    ctx.ellipse(0, 8, 22, 12, 0, 0, Math.PI * 2);
+    ctx.fill();
+    ctx.globalAlpha = 1;
+    ctx.restore();
+  }
+  if (spr) ctx.drawImage(spr, sx, sy, 48, 48, dx, dy, 48, 48);
+  if (a !== player && a.displayName) {
+    ctx.save();
+    const tx = Math.floor(a.x - cam.x);
+    const ty = Math.floor(a.y - 48 - cam.y);
+    ctx.font = "600 16px 'Inter',Arial,sans-serif";
+    ctx.textAlign = "center";
+    ctx.fillStyle = "rgba(0,0,0,0.55)";
+    ctx.fillText(a.displayName, tx, ty + 1);
+    ctx.fillStyle = a.accent || "#f5fbff";
+    ctx.fillText(a.displayName, tx, ty);
+    if (a.role) {
+      ctx.font = "500 12px 'Inter',Arial,sans-serif";
+      ctx.fillStyle = "rgba(240, 250, 255, 0.85)";
+      ctx.fillText(a.role, tx, ty + 14);
+    }
+    ctx.restore();
+  }
 }
 function drawAllActors() {
   const list = actors.slice().sort((a, b) => (a.y - b.y));
@@ -356,80 +947,158 @@ function drawAllActors() {
 
 // --- Minimap ---
 function drawMinimap() {
-  const mmW = 180, mmH = 180;
-  const scale = mmW / MAP_W;
-  const px = W - mmW - 18, py = 18;
+  const size = 200;
+  const radius = size / 2;
+  const cx = W - radius - 40;
+  const cy = radius + 48;
+  const scale = size / Math.max(MAP_W, MAP_H);
+  const offsetX = -MAP_W * scale / 2;
+  const offsetY = -MAP_H * scale / 2;
+
   ctx.save();
-  ctx.globalAlpha = 0.92;
-  ctx.fillStyle = "#181c22";
-  ctx.fillRect(px - 4, py - 4, mmW + 8, mmH + 8);
-  ctx.globalAlpha = 1;
-  // Tiles (nur grob, farbcodiert)
+  ctx.translate(cx, cy);
+
+  ctx.save();
+  ctx.globalAlpha = 0.45;
+  ctx.fillStyle = "rgba(26, 51, 83, 0.45)";
+  ctx.beginPath();
+  ctx.arc(0, 0, radius + 26, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.restore();
+
+  ctx.save();
+  ctx.shadowColor = "rgba(0, 0, 0, 0.55)";
+  ctx.shadowBlur = 18;
+  ctx.fillStyle = "rgba(8, 13, 20, 0.92)";
+  ctx.beginPath();
+  ctx.arc(0, 0, radius + 10, 0, Math.PI * 2);
+  ctx.fill();
+  ctx.restore();
+
+  ctx.save();
+  ctx.beginPath();
+  ctx.arc(0, 0, radius, 0, Math.PI * 2);
+  ctx.fillStyle = "rgba(16, 22, 30, 0.96)";
+  ctx.fill();
+  ctx.clip();
+
+  ctx.save();
+  ctx.translate(offsetX, offsetY);
   for (let y = 0; y < MAP_H; y++) {
     for (let x = 0; x < MAP_W; x++) {
-      let t = map[y * MAP_W + x];
-      ctx.fillStyle =
-        t === 2 ? "#888" : // path
-        t === 1 ? "#b98" : // dirt
-        t === 4 ? "#3af" : // water
-        t === 5 ? "#964" : // wood
-        t === 6 ? "#222" : // wall
-        "#2b5"; // grass
-      ctx.fillRect(px + x * scale, py + y * scale, scale, scale);
+      const t = map[y * MAP_W + x];
+      ctx.fillStyle = MINIMAP_TILE_COLORS[t] || MINIMAP_TILE_COLORS[0];
+      ctx.fillRect(x * scale, y * scale, Math.ceil(scale) + 0.5, Math.ceil(scale) + 0.5);
     }
   }
-  // Häuser umrisse
-  ctx.strokeStyle = "#fff8";
-  ctx.lineWidth = 1;
+
+  ctx.strokeStyle = "rgba(255, 255, 255, 0.25)";
+  ctx.lineWidth = 1.2;
   for (const h of HOUSES) {
     const [sx, sy, w, hh] = h.rect;
-    ctx.strokeRect(px + sx * scale, py + sy * scale, w * scale, hh * scale);
+    ctx.strokeRect(sx * scale, sy * scale, w * scale, hh * scale);
   }
-  // NPCs
+
   for (const a of actors) {
     if (a === player) continue;
-    ctx.fillStyle = "#ff0";
+    ctx.fillStyle = "rgba(255, 220, 120, 0.9)";
     ctx.beginPath();
-    ctx.arc(px + a.x / TILE * scale, py + a.y / TILE * scale, 4, 0, 2 * Math.PI);
+    ctx.arc((a.x / TILE) * scale, (a.y / TILE) * scale, 3, 0, Math.PI * 2);
     ctx.fill();
   }
-  // Spieler
+
   ctx.save();
-  ctx.translate(px + player.x / TILE * scale, py + player.y / TILE * scale);
-  // Richtungspfeil: berechne Winkel aus letzter Bewegungsrichtung
+  ctx.translate((player.x / TILE) * scale, (player.y / TILE) * scale);
   let angle = 0;
   if (lastMoveDir.x !== 0 || lastMoveDir.y !== 0) {
     angle = Math.atan2(lastMoveDir.y, lastMoveDir.x);
   } else {
-    // fallback: Blickrichtung (player.dir)
-    angle = [Math.PI/2, Math.PI, 0, -Math.PI/2][player.dir] || 0;
+    angle = [Math.PI / 2, Math.PI, 0, -Math.PI / 2][player.dir] || 0;
   }
-  ctx.rotate(angle + Math.PI/2); // Pfeil zeigt nach oben
-  ctx.fillStyle = "#0ff";
+  ctx.rotate(angle + Math.PI / 2);
+  ctx.fillStyle = "#56cfe1";
   ctx.beginPath();
   ctx.moveTo(0, -7);
-  ctx.lineTo(5, 7);
-  ctx.lineTo(-5, 7);
+  ctx.lineTo(5, 6);
+  ctx.lineTo(-5, 6);
   ctx.closePath();
   ctx.fill();
   ctx.restore();
+
+  ctx.restore(); // map translation
+  ctx.restore(); // clip circle
+
+  ctx.strokeStyle = "rgba(86, 207, 225, 0.65)";
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.arc(0, 0, radius, 0, Math.PI * 2);
+  ctx.stroke();
+
+  ctx.strokeStyle = "rgba(255, 255, 255, 0.12)";
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.arc(0, 0, radius + 10, 0, Math.PI * 2);
+  ctx.stroke();
+
+  ctx.fillStyle = "rgba(255, 255, 255, 0.7)";
+  ctx.font = "600 12px Inter, sans-serif";
+  ctx.textAlign = "center";
+  ctx.fillText("KARTE", 0, radius + 18);
+
   ctx.restore();
 }
 
 // --- Lighting & Day-Night ---
 function drawLighting() {
-  const t = Math.abs(Math.sin(timeMin / 1440 * Math.PI * 2));
+  const cycle = (timeMin % (24 * 60)) / (24 * 60);
+  const dayStrength = (Math.cos((cycle - 0.5) * Math.PI * 2) + 1) / 2;
+  const nightFactor = 1 - dayStrength;
+
+  ctx.save();
   ctx.globalCompositeOperation = "multiply";
-  ctx.fillStyle = `rgba(${Math.floor(30 + 60 * t)},${Math.floor(40 + 50 * t)},${Math.floor(80 + 100 * t)},${0.25 + 0.25 * t})`;
+  const r = Math.floor(36 + 120 * nightFactor);
+  const g = Math.floor(48 + 95 * nightFactor);
+  const b = Math.floor(88 + 110 * nightFactor);
+  const alpha = 0.18 + 0.4 * nightFactor;
+  ctx.fillStyle = `rgba(${r},${g},${b},${alpha})`;
   ctx.fillRect(0, 0, W, H);
-  const lamp = img(ASSETS.fx.radial);
-  if (lamp) {
-    ctx.globalCompositeOperation = "screen";
-    ctx.globalAlpha = 0.6 * (0.4 + 0.6 * (1 - t));
-    ctx.drawImage(lamp, Math.floor(player.x - 128 - cam.x), Math.floor(player.y - 160 - cam.y));
-    ctx.globalAlpha = 1;
+  ctx.restore();
+
+  ctx.save();
+  ctx.globalCompositeOperation = "soft-light";
+  const gradient = ctx.createLinearGradient(0, 0, 0, H);
+  gradient.addColorStop(0, `rgba(255, 240, 214, ${0.08 * dayStrength})`);
+  gradient.addColorStop(1, `rgba(18, 30, 54, ${0.25 * nightFactor})`);
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, W, H);
+  ctx.restore();
+
+  const ambient = img(ASSETS.fx.ambient);
+  if (ambient) {
+    ctx.save();
+    ctx.globalCompositeOperation = "overlay";
+    ctx.globalAlpha = 0.15 + 0.2 * nightFactor;
+    ctx.drawImage(ambient, 0, 0, W, H);
+    ctx.restore();
   }
-  ctx.globalCompositeOperation = "source-over";
+}
+
+function drawVignette() {
+  ctx.save();
+  ctx.globalCompositeOperation = "multiply";
+  const radius = Math.sqrt(W * W + H * H) * 0.55;
+  const vignette = ctx.createRadialGradient(W / 2, H / 2, radius * 0.3, W / 2, H / 2, radius);
+  vignette.addColorStop(0, "rgba(0,0,0,0)");
+  vignette.addColorStop(1, "rgba(0,0,0,0.55)");
+  ctx.fillStyle = vignette;
+  ctx.fillRect(0, 0, W, H);
+  ctx.restore();
+
+  ctx.save();
+  ctx.globalCompositeOperation = "screen";
+  ctx.fillStyle = "rgba(90, 170, 255, 0.07)";
+  ctx.fillRect(0, 0, W, H * 0.12);
+  ctx.restore();
 }
 
 // --- Resize ---
@@ -441,19 +1110,14 @@ function onResize() {
 addEventListener("resize", onResize);
 
 // --- Hotkeys & Plant Selection ---
-addEventListener("keydown", (e) => {
-  if (e.key === '1') { player.selectedSeed = "cabbage"; tryPlant("cabbage"); }
-  if (e.key === '2') { player.selectedSeed = "corn"; tryPlant("corn"); }
-  if (e.key === '3') { player.selectedSeed = "flower"; tryPlant("flower"); }
-  if (e.key === 'q') { cycleSeed(-1); }
-  if (e.key === 'e') { cycleSeed(1); }
-  if (e.key === '4') tryPlaceStone();
-});
 function cycleSeed(dir) {
-  const ids = Object.keys(player.inv.seeds);
+  const ids = SEED_ORDER;
+  if (!ids.length) return;
   let idx = ids.indexOf(player.selectedSeed);
+  if (idx === -1) idx = 0;
   idx = (idx + dir + ids.length) % ids.length;
   player.selectedSeed = ids[idx];
+  onSeedChanged(true);
 }
 
 // --- Main Loop ---
@@ -468,14 +1132,18 @@ function loop(t) {
     timeTick(dt);
     renderTopbar();
   }
+  detectContext();
+  refreshContextHint();
   // Draw
   ctx.clearRect(0, 0, W, H);
   drawTiles();
   drawPlants();
-  drawAllActors();
-  drawHouseOverlay(); // Häuser sichtbar machen
-  drawLighting();
-  drawMinimap(); // Minimap zeichnen (immer!)
+    drawInteractionHighlight();
+    drawAllActors();
+    if (DEBUG_OVERLAY) drawHouseOverlay();
+    drawLighting();
+    drawVignette();
+    drawMinimap(); // Minimap zeichnen (immer!)
   if (paused) {
     ctx.save();
     ctx.globalAlpha = 0.7;
@@ -494,25 +1162,7 @@ function loop(t) {
 // --- Boot ---
 (async function () {
   onResize();
-  await loadAll();
-  requestAnimationFrame(loop);
-})();
-    ctx.fillStyle = "#222";
-    ctx.fillRect(0, 0, W, H);
-    ctx.globalAlpha = 1;
-    ctx.fillStyle = "#fff";
-    ctx.font = "bold 48px Inter,Arial,sans-serif";
-    ctx.textAlign = "center";
-    ctx.fillText("PAUSE", W / 2, H / 2);
-    ctx.restore();
-  }
-  requestAnimationFrame(loop);
-}
-
-// --- Boot ---
-(async function () {
-  onResize();
-  await loadAll();
+  await Promise.all([loadAll(), sfx.ready]);
   requestAnimationFrame(loop);
 })();
 

--- a/sfx.js
+++ b/sfx.js
@@ -1,28 +1,139 @@
-// Lightweight audio manager with pooled HTMLAudioElements, now with more SFX
+// Modern audio manager with WebAudio acceleration, randomised pitch and graceful fallbacks
 export class SFX {
   constructor(manifest) {
-    this.buf = new Map();
     this.enabled = true;
-    this.load(manifest);
+    this.entries = new Map();
+    this.ctx = null;
+    this.useWebAudio = false;
+    this.ready = this.init(manifest);
   }
-  load(manifest) {
-    for (const [k, url] of Object.entries(manifest)) {
+
+  async init(manifest) {
+    const AudioCtx = window.AudioContext || window.webkitAudioContext;
+    if (AudioCtx) {
       try {
-        const a = new Audio(url);
-        a.preload = "auto";
-        a.onerror = () => { this.buf.delete(k); };
-        this.buf.set(k, a);
-      } catch (e) {
-        // Datei nicht gefunden/ladbar
+        this.ctx = new AudioCtx();
+        this.useWebAudio = true;
+      } catch (_) {
+        this.ctx = null;
+        this.useWebAudio = false;
       }
     }
+
+    const loaders = Object.entries(manifest).map(async ([key, value]) => {
+      const urls = Array.isArray(value) ? value : [value];
+      const entry = { urls, buffers: [], html: [] };
+      this.entries.set(key, entry);
+
+      await Promise.all(urls.map(async (url) => {
+        if (this.ctx) {
+          try {
+            const res = await fetch(url);
+            if (!res.ok) throw new Error(`HTTP ${res.status}`);
+            const arr = await res.arrayBuffer();
+            const buffer = await new Promise((resolve, reject) => {
+              this.ctx.decodeAudioData(arr.slice(0), resolve, reject);
+            });
+            entry.buffers.push(buffer);
+          } catch (_) {
+            // fallback handled by HTML audio below
+          }
+        }
+
+        try {
+          const tag = new Audio(url);
+          tag.preload = "auto";
+          tag.onerror = () => { /* ignore decode errors, fallback already in place */ };
+          entry.html.push(tag);
+        } catch (_) {
+          // Ignore environments without HTMLAudioElement support
+        }
+      }));
+    });
+
+    await Promise.all(loaders);
+    if (this.entries.size === 0) this.enabled = false;
   }
-  play(key, vol = 1) {
+
+  pick(list) {
+    if (!list || !list.length) return null;
+    return list[Math.floor(Math.random() * list.length)];
+  }
+
+  play(key, volumeOrOpts = 1, maybeOpts) {
     if (!this.enabled) return;
-    const src = this.buf.get(key);
-    if (!src) return;
-    const a = src.cloneNode();
-    a.volume = vol;
-    a.play().catch(() => { });
+    const entry = this.entries.get(key);
+    if (!entry) return;
+
+    let opts;
+    if (typeof volumeOrOpts === "object") {
+      opts = volumeOrOpts || {};
+    } else {
+      opts = maybeOpts || {};
+      if (typeof volumeOrOpts === "number") opts.volume = volumeOrOpts;
+    }
+
+    let volume = typeof opts.volume === "number" ? opts.volume : 1;
+    volume = Math.min(1, Math.max(0, volume));
+
+    let rate = typeof opts.rate === "number" ? opts.rate : 1;
+    const rateVariance = opts.rateRange ?? opts.randomRate;
+    if (Array.isArray(rateVariance)) {
+      const [min, max] = rateVariance;
+      rate = min + Math.random() * (max - min);
+    } else if (typeof rateVariance === "number") {
+      rate = rate * (1 + (Math.random() * 2 - 1) * rateVariance);
+    }
+    rate = Math.max(0.25, rate);
+
+    let detune = typeof opts.detune === "number" ? opts.detune : 0;
+    const detuneVariance = opts.detuneRange ?? opts.randomDetune;
+    if (Array.isArray(detuneVariance)) {
+      const [min, max] = detuneVariance;
+      detune += min + Math.random() * (max - min);
+    } else if (typeof detuneVariance === "number") {
+      detune += (Math.random() * 2 - 1) * detuneVariance;
+    }
+
+    let offset = typeof opts.offset === "number" ? opts.offset : 0;
+    const offsetVariance = opts.offsetRange;
+    if (Array.isArray(offsetVariance)) {
+      const [min, max] = offsetVariance;
+      offset += min + Math.random() * (max - min);
+    } else if (typeof offsetVariance === "number") {
+      offset += (Math.random() * 2 - 1) * offsetVariance;
+    }
+    offset = Math.max(0, offset);
+
+    if (this.ctx && this.useWebAudio && entry.buffers.length) {
+      const buffer = this.pick(entry.buffers);
+      if (!buffer) return;
+      const source = this.ctx.createBufferSource();
+      source.buffer = buffer;
+      if (detune) source.detune.value = detune;
+      if (rate !== 1) source.playbackRate.value = rate;
+      const gain = this.ctx.createGain();
+      gain.gain.value = volume;
+      source.connect(gain).connect(this.ctx.destination);
+      if (this.ctx.state === "suspended") {
+        this.ctx.resume().catch(() => {});
+      }
+      try {
+        source.start(0, offset);
+      } catch (_) {
+        source.start();
+      }
+      return;
+    }
+
+    const clip = this.pick(entry.html);
+    if (!clip) return;
+    const node = clip.cloneNode();
+    node.volume = volume;
+    if (rate !== 1 && node.playbackRate) node.playbackRate = rate;
+    if (offset) {
+      try { node.currentTime = offset; } catch (_) { /* ignore */ }
+    }
+    node.play().catch(() => {});
   }
 }

--- a/style.css
+++ b/style.css
@@ -1,11 +1,574 @@
-html,body{margin:0;padding:0;background:#0e1215;color:#e6e6e6;font-family:Inter,system-ui,Segoe UI,Arial,sans-serif;overflow:hidden}
-#game{display:block;width:100vw;height:100vh;image-rendering:pixelated;image-rendering:crisp-edges;background:#0a0f0a}
-.topbar{position:fixed;left:12px;top:10px;background:rgba(15,18,22,.75);backdrop-filter:blur(4px);padding:6px 10px;border-radius:12px;display:flex;gap:12px;align-items:center;box-shadow:0 2px 6px rgba(0,0,0,.35)}
-.topbar span{opacity:.9}
-.panel{position:fixed;inset:0;display:grid;place-items:center;background:rgba(0,0,0,.45)}
-.panel.hidden{display:none}
-.panel-inner{width:min(520px,90vw);max-height:80vh;overflow:auto;background:#1b2127;border:1px solid #2a3138;border-radius:16px;box-shadow:0 10px 40px rgba(0,0,0,.5);padding:18px}
-button{background:#2b7ce2;border:none;color:#fff;padding:10px 14px;border-radius:10px;cursor:pointer;font-size:1rem;transition:filter .15s,background .15s}
-button:hover,button:focus{filter:brightness(1.1);background:#1a5cb8;outline:none}
-#hint{opacity:.7;font-size:.95em}
-.panel.paused{display:grid;place-items:center;background:rgba(0,0,0,.6);z-index:100}
+:root {
+  --bg-0: #04070d;
+  --bg-1: #0f1624;
+  --text: #f5fbff;
+  --muted: rgba(255, 255, 255, 0.7);
+  --accent: #56cfe1;
+  --accent-soft: #72efdd;
+  --glass-bg-strong: linear-gradient(135deg, rgba(12, 20, 32, 0.92), rgba(5, 10, 18, 0.88));
+  --glass-bg-soft: linear-gradient(135deg, rgba(8, 14, 22, 0.92), rgba(5, 9, 16, 0.88));
+  --glass-bg-warm: linear-gradient(135deg, rgba(8, 14, 22, 0.9), rgba(5, 9, 16, 0.92));
+  --panel-bg: linear-gradient(135deg, rgba(12, 20, 32, 0.96), rgba(6, 10, 18, 0.93));
+  --glass-border-soft: rgba(86, 207, 225, 0.25);
+  --glass-border-strong: rgba(86, 207, 225, 0.32);
+  --glass-border-muted: rgba(86, 207, 225, 0.18);
+  --glass-border-highlight: rgba(114, 239, 221, 0.45);
+  --shadow-lg: 0 28px 60px rgba(0, 0, 0, 0.55);
+  --shadow-md: 0 24px 48px rgba(0, 0, 0, 0.55);
+  --shadow-sm: 0 20px 36px rgba(0, 0, 0, 0.5);
+  --blur-strong: blur(18px);
+  --blur-medium: blur(12px);
+  --chip-surface: rgba(255, 255, 255, 0.06);
+  --chip-border: rgba(255, 255, 255, 0.12);
+  --chip-highlight: rgba(255, 255, 255, 0.08);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+.hidden {
+  display: none !important;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  min-height: 100%;
+  background: radial-gradient(circle at 20% 15%, #132238, #04070d 65%);
+  color: var(--text);
+  font-family: "Inter", system-ui, "Segoe UI", Arial, sans-serif;
+  overflow: hidden;
+}
+
+body {
+  position: relative;
+}
+
+body::before,
+body::after {
+  content: "";
+  position: fixed;
+  inset: -30vh -30vw;
+  pointer-events: none;
+  z-index: 0;
+  opacity: 0.9;
+  filter: blur(80px);
+  transform: translate3d(0, 0, 0);
+}
+
+body::before {
+  background: radial-gradient(circle at 18% 25%, rgba(86, 207, 225, 0.24), transparent 60%);
+}
+
+body::after {
+  background: radial-gradient(circle at 82% 78%, rgba(114, 239, 221, 0.18), transparent 55%);
+}
+
+#ui {
+  position: relative;
+  z-index: 3;
+}
+
+#game {
+  display: block;
+  position: relative;
+  width: 100vw;
+  height: 100vh;
+  background: #050b13;
+  image-rendering: pixelated;
+  image-rendering: crisp-edges;
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.05), 0 40px 120px rgba(0, 0, 0, 0.55);
+  filter: saturate(1.05) contrast(1.02);
+  z-index: 1;
+}
+
+.topbar {
+  position: fixed;
+  top: 26px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 20px 26px 18px;
+  border-radius: 26px;
+  background: var(--glass-bg-strong);
+  border: 1px solid var(--glass-border-soft);
+  box-shadow: var(--shadow-lg), inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  backdrop-filter: var(--blur-strong);
+  color: var(--text);
+  z-index: 4;
+}
+
+.topbar__row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 14px;
+}
+
+.top-pill {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 18px 8px 36px;
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(86, 207, 225, 0.22);
+  color: rgba(245, 251, 255, 0.94);
+  font-size: 0.9rem;
+  letter-spacing: 0.02em;
+  font-variant-numeric: tabular-nums;
+  text-shadow: none;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.top-pill::before {
+  content: "";
+  position: absolute;
+  left: 12px;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, rgba(114, 239, 221, 0.9), rgba(86, 207, 225, 0.6));
+  box-shadow: 0 0 14px rgba(86, 207, 225, 0.6);
+}
+
+#stamina {
+  --fill: 1;
+}
+
+#stamina::before {
+  background: linear-gradient(135deg, #fcbf49, #ff9f1c);
+  box-shadow: 0 0 14px rgba(255, 191, 64, 0.55);
+}
+
+#stamina::after {
+  content: "";
+  position: absolute;
+  left: 18px;
+  bottom: -6px;
+  width: calc(100% - 36px);
+  height: 3px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(114, 239, 221, 0.9), rgba(86, 207, 225, 0.7));
+  transform-origin: left center;
+  transform: scaleX(var(--fill));
+  transition: transform 0.2s ease-out;
+  opacity: 0.95;
+}
+
+#money::before {
+  background: linear-gradient(135deg, #ffd166, #fcbf49);
+  box-shadow: 0 0 14px rgba(255, 209, 102, 0.6);
+}
+
+#clock::before {
+  background: linear-gradient(135deg, #9d4edd, #7b2ff7);
+  box-shadow: 0 0 14px rgba(157, 78, 221, 0.55);
+}
+
+#hint {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+  font-size: 0.8rem;
+  padding: 10px 12px;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px solid var(--glass-border-muted);
+  backdrop-filter: var(--blur-medium);
+}
+
+.hint-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 10px;
+  background: rgba(86, 207, 225, 0.1);
+  border: 1px solid var(--glass-border-soft);
+  backdrop-filter: blur(6px);
+  color: rgba(255, 255, 255, 0.9);
+  text-shadow: none;
+}
+
+.hint-item.emphasised {
+  background: rgba(114, 239, 221, 0.18);
+  border-color: rgba(114, 239, 221, 0.35);
+  color: #eafffb;
+}
+
+.hint-key {
+  font-weight: 600;
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.hint-desc {
+  font-size: 0.76rem;
+  color: var(--muted);
+}
+
+.hint-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px 8px;
+  margin-left: 4px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(86, 207, 225, 0.35), rgba(114, 239, 221, 0.6));
+  color: #041019;
+  font-weight: 600;
+}
+
+.hint-count {
+  margin-left: 6px;
+  font-weight: 600;
+  color: #fff;
+}
+
+.hint-sep {
+  color: rgba(255, 255, 255, 0.35);
+  font-weight: 500;
+}
+
+.hint-gap {
+  margin: 0 6px;
+}
+
+.bottom-ui {
+  position: fixed;
+  left: 50%;
+  bottom: 36px;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  z-index: 4;
+}
+
+.seed-wheel {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 18px;
+  border-radius: 24px;
+  background: var(--glass-bg-soft);
+  border: 1px solid var(--glass-border-soft);
+  box-shadow: var(--shadow-md);
+  backdrop-filter: var(--blur-strong);
+}
+
+.seed-card {
+  position: relative;
+  display: grid;
+  grid-template-columns: 36px auto;
+  grid-template-rows: auto auto;
+  align-items: center;
+  gap: 2px 10px;
+  padding: 8px 16px 8px 10px;
+  border-radius: 18px;
+  border: 1px solid transparent;
+  background: rgba(255, 255, 255, 0.02);
+  color: rgba(245, 251, 255, 0.92);
+  cursor: pointer;
+  transition: transform 0.15s ease, border-color 0.18s ease, background 0.18s ease, box-shadow 0.18s ease;
+}
+
+.seed-card__icon {
+  grid-row: 1 / span 2;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 12px;
+  background: var(--chip-surface);
+  overflow: hidden;
+}
+
+.seed-card__icon img {
+  width: 28px;
+  height: 28px;
+  image-rendering: pixelated;
+}
+
+.seed-card__label {
+  grid-column: 2;
+  grid-row: 1;
+  font-size: 0.82rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.seed-card__count {
+  grid-column: 2;
+  grid-row: 2;
+  font-size: 0.75rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.seed-card__hotkey {
+  position: absolute;
+  top: 6px;
+  right: 10px;
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: var(--chip-highlight);
+  color: rgba(255, 255, 255, 0.82);
+  font-size: 0.7rem;
+  letter-spacing: 0.08em;
+}
+
+.seed-card:hover,
+.seed-card:focus-visible {
+  border-color: var(--glass-border-highlight);
+  background: rgba(114, 239, 221, 0.12);
+  outline: none;
+}
+
+.seed-card.active {
+  background: rgba(114, 239, 221, 0.2);
+  border-color: rgba(114, 239, 221, 0.65);
+  box-shadow: 0 14px 28px rgba(114, 239, 221, 0.24);
+  transform: translateY(-4px);
+}
+
+.seed-card--empty {
+  opacity: 0.55;
+}
+
+.context-hint {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 16px;
+  border-radius: 16px;
+  background: var(--glass-bg-warm);
+  border: 1px solid var(--glass-border-strong);
+  box-shadow: var(--shadow-sm);
+  backdrop-filter: var(--blur-strong);
+  color: rgba(245, 251, 255, 0.95);
+  font-size: 0.9rem;
+  letter-spacing: 0.01em;
+}
+
+.context-hint__icon {
+  width: 32px;
+  height: 32px;
+  padding: 4px;
+  border-radius: 10px;
+  background: var(--chip-surface);
+  object-fit: contain;
+  image-rendering: pixelated;
+}
+
+.context-hint__label {
+  white-space: nowrap;
+}
+
+.context-hint--warning {
+  border-color: rgba(255, 118, 118, 0.5);
+  background: linear-gradient(135deg, rgba(32, 12, 18, 0.92), rgba(46, 16, 22, 0.9));
+  color: #ffe5e5;
+}
+
+.context-hint--warning .context-hint__icon {
+  background: rgba(255, 118, 118, 0.22);
+}
+
+.panel {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: rgba(3, 6, 12, 0.6);
+  backdrop-filter: var(--blur-strong);
+  z-index: 5;
+}
+
+.panel.hidden {
+  display: none;
+}
+
+.panel-inner {
+  width: min(640px, 92vw);
+  max-height: 82vh;
+  overflow: hidden;
+  padding: 28px 32px;
+  border-radius: 26px;
+  background: var(--panel-bg);
+  border: 1px solid var(--glass-border-soft);
+  box-shadow: 0 36px 80px rgba(0, 0, 0, 0.58), 0 0 0 1px rgba(86, 207, 225, 0.12) inset;
+  color: var(--text);
+}
+
+#shop {
+  --shop-accent: var(--accent);
+}
+
+#shop .panel-inner {
+  border: 1px solid var(--glass-border-strong);
+  box-shadow: 0 36px 80px rgba(0, 0, 0, 0.6), 0 0 40px rgba(86, 207, 225, 0.18);
+}
+
+.shop-header {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  margin-bottom: 22px;
+}
+
+.shop-portrait {
+  width: 72px;
+  height: 72px;
+  border-radius: 18px;
+  background: var(--chip-surface);
+  border: 1px solid var(--chip-border);
+  object-fit: contain;
+  image-rendering: pixelated;
+}
+
+.shop-header__text h3 {
+  margin: 0;
+  font-size: 1.35rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--shop-accent);
+}
+
+.shop-header__text p {
+  margin: 6px 0 0;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.68);
+  line-height: 1.4;
+}
+
+.shop-close {
+  margin-left: auto;
+  width: 42px;
+  height: 42px;
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  background: var(--chip-surface);
+  color: rgba(245, 251, 255, 0.92);
+  font-size: 1.4rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: transform 0.15s ease, border-color 0.2s ease, background 0.2s ease;
+}
+
+.shop-close:hover,
+.shop-close:focus-visible {
+  background: rgba(114, 239, 221, 0.18);
+  border-color: var(--glass-border-highlight);
+  outline: none;
+  transform: translateY(-1px);
+}
+
+.shop-items {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  max-height: calc(80vh - 160px);
+  overflow-y: auto;
+  padding-right: 6px;
+}
+
+button {
+  border: none;
+  background: none;
+  color: inherit;
+  font: inherit;
+  padding: 0;
+  cursor: pointer;
+}
+
+button:focus-visible {
+  outline: none;
+}
+
+.shop-item {
+  width: 100%;
+  display: grid;
+  grid-template-columns: 56px 1fr auto;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 18px;
+  border-radius: 18px;
+  border: 1px solid var(--glass-border-muted);
+  background: rgba(255, 255, 255, 0.02);
+  transition: transform 0.16s ease, border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.shop-item__icon {
+  width: 56px;
+  height: 56px;
+  border-radius: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--chip-surface);
+  border: 1px solid var(--chip-border);
+  overflow: hidden;
+}
+
+.shop-item__icon img {
+  width: 40px;
+  height: 40px;
+  image-rendering: pixelated;
+}
+
+.shop-item__info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.shop-item__title {
+  font-size: 1rem;
+  letter-spacing: 0.04em;
+  color: rgba(245, 251, 255, 0.95);
+}
+
+.shop-item__desc {
+  font-size: 0.82rem;
+  color: rgba(255, 255, 255, 0.65);
+  line-height: 1.45;
+}
+
+.shop-item__price {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--shop-accent);
+  padding-left: 12px;
+}
+
+.shop-item:hover,
+.shop-item:focus-visible {
+  border-color: var(--glass-border-highlight);
+  background: rgba(114, 239, 221, 0.12);
+  box-shadow: 0 18px 36px rgba(114, 239, 221, 0.2);
+  transform: translateY(-2px);
+}
+
+.shop-item:active {
+  transform: translateY(0);
+}
+
+.panel.paused {
+  display: grid;
+  place-items: center;
+  background: rgba(0, 0, 0, 0.6);
+  z-index: 100;
+}


### PR DESCRIPTION
## Summary
- add shared helpers for seed inventory, direction offsets, and shop state so input, planting, and shops reuse a single source of truth
- update movement handling and planting logic to leverage the new helpers and remove duplicated offset arrays
- extract repeated frosted surface colors into CSS variables and apply them across the HUD chips to reduce styling duplication

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c9dc12fa788320bc336630eaff8ea5